### PR TITLE
Update to new JSON from endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,13 +33,13 @@ main = do
   let configuration = StreamsConfiguration UsEast1
   ListStreamsResponse{..} ← simpleAws awsConfiguration configuration listStreams
   DescribeStreamResponse StreamDescription{..} ←
-    simpleAws awsConfiguration configuration . describeStream $
-      head _lstrStreamIds
+    let Just streamArn = _sStreamArn $ head _lstrStreams
+    in simpleAws awsConfiguration configuration $ describeStream streamArn
 
   GetShardIteratorResponse{..} ← simpleAws awsConfiguration configuration $
     let Just shardId = _shShardId $ head _sdShards
-        Just streamId = _sdStreamId
-    in getShardIterator streamId shardId ShardIteratorLatest
+        Just streamArn = _sdStreamArn
+    in getShardIterator streamArn shardId ShardIteratorLatest
 
   resp ← simpleAws awsConfiguration configuration $ getRecords _gsirShardIterator
   print resp

--- a/src/Aws/DynamoDb/Streams/Commands/DescribeStream.hs
+++ b/src/Aws/DynamoDb/Streams/Commands/DescribeStream.hs
@@ -44,12 +44,12 @@ module Aws.DynamoDb.Streams.Commands.DescribeStream
 ) where
 
 import Aws.Core
+import Aws.General (Arn)
 import Aws.DynamoDb.Streams.Core
 import Aws.DynamoDb.Streams.Types
 import Control.Applicative
 import Control.Applicative.Unicode
 import Data.Aeson
-import qualified Data.Text as T
 import Data.Typeable
 import Prelude.Unicode
 
@@ -62,8 +62,8 @@ data DescribeStream
   , _dstLimit ∷ !(Maybe Int)
     -- ^ The maximum number of shard objects to return.
 
-  , _dstStreamArn ∷ !T.Text
-    -- ^ The unique ID of the stream to be described.
+  , _dstStreamArn ∷ !Arn
+    -- ^ The ARN of the stream to be described.
 
   } deriving (Eq, Ord, Show, Read, Typeable)
 
@@ -76,7 +76,7 @@ data DescribeStream
 -- @
 --
 describeStream
-  ∷ T.Text
+  ∷ Arn
   → DescribeStream
 describeStream streamArn = DescribeStream
   { _dstExclusiveStartShardId = Nothing
@@ -139,7 +139,7 @@ dstLimit i DescribeStream{..} =
 --
 dstStreamArn
   ∷ Functor f
-  ⇒ (T.Text → f T.Text)
+  ⇒ (Arn → f Arn)
   → DescribeStream
   → f DescribeStream
 dstStreamArn i DescribeStream{..} =

--- a/src/Aws/DynamoDb/Streams/Commands/DescribeStream.hs
+++ b/src/Aws/DynamoDb/Streams/Commands/DescribeStream.hs
@@ -35,7 +35,7 @@ module Aws.DynamoDb.Streams.Commands.DescribeStream
   -- ** Lenses
 , dstExclusiveStartShardId
 , dstLimit
-, dstStreamId
+, dstStreamArn
 
   -- * Response
 , DescribeStreamResponse(..)
@@ -49,6 +49,7 @@ import Aws.DynamoDb.Streams.Types
 import Control.Applicative
 import Control.Applicative.Unicode
 import Data.Aeson
+import qualified Data.Text as T
 import Data.Typeable
 import Prelude.Unicode
 
@@ -61,7 +62,7 @@ data DescribeStream
   , _dstLimit ∷ !(Maybe Int)
     -- ^ The maximum number of shard objects to return.
 
-  , _dstStreamId ∷ !StreamId
+  , _dstStreamArn ∷ !T.Text
     -- ^ The unique ID of the stream to be described.
 
   } deriving (Eq, Ord, Show, Read, Typeable)
@@ -75,19 +76,19 @@ data DescribeStream
 -- @
 --
 describeStream
-  ∷ StreamId
+  ∷ T.Text
   → DescribeStream
-describeStream streamId = DescribeStream
+describeStream streamArn = DescribeStream
   { _dstExclusiveStartShardId = Nothing
   , _dstLimit = Nothing
-  , _dstStreamId = streamId
+  , _dstStreamArn = streamArn
   }
 
 instance ToJSON DescribeStream where
   toJSON DescribeStream{..} = object
     [ "ExclusiveStartShardId" .= _dstExclusiveStartShardId
     , "Limit" .= _dstLimit
-    , "StreamId".= _dstStreamId
+    , "StreamArn".= _dstStreamArn
     ]
 
 instance FromJSON DescribeStream where
@@ -96,7 +97,7 @@ instance FromJSON DescribeStream where
       pure DescribeStream
         ⊛ o .:? "ExclusiveStartShardId"
         ⊛ o .:? "Limit"
-        ⊛ o .: "StreamId"
+        ⊛ o .: "StreamArn"
 
 -- | A lens for '_dstExclusiveStartShardId'.
 --
@@ -130,21 +131,21 @@ dstLimit i DescribeStream{..} =
     <$> i _dstLimit
 {-# INLINE dstLimit #-}
 
--- | A lens for '_dstStreamId'.
+-- | A lens for '_dstStreamArn'.
 --
 -- @
--- 'dstStreamId' ∷ Lens' 'DescribeStream' 'StreamId'
+-- 'dstStreamArn' ∷ Lens' 'DescribeStream' 'StreamArn'
 -- @
 --
-dstStreamId
+dstStreamArn
   ∷ Functor f
-  ⇒ (StreamId → f StreamId)
+  ⇒ (T.Text → f T.Text)
   → DescribeStream
   → f DescribeStream
-dstStreamId i DescribeStream{..} =
-  (\_dstStreamId → DescribeStream{..})
-    <$> i _dstStreamId
-{-# INLINE dstStreamId #-}
+dstStreamArn i DescribeStream{..} =
+  (\_dstStreamArn → DescribeStream{..})
+    <$> i _dstStreamArn
+{-# INLINE dstStreamArn #-}
 
 data DescribeStreamResponse
   = DescribeStreamResponse

--- a/src/Aws/DynamoDb/Streams/Commands/GetShardIterator.hs
+++ b/src/Aws/DynamoDb/Streams/Commands/GetShardIterator.hs
@@ -45,12 +45,12 @@ module Aws.DynamoDb.Streams.Commands.GetShardIterator
 ) where
 
 import Aws.Core
+import Aws.General (Arn)
 import Aws.DynamoDb.Streams.Core
 import Aws.DynamoDb.Streams.Types
 import Control.Applicative
 import Control.Applicative.Unicode
 import Data.Aeson
-import qualified Data.Text as T
 import Data.Typeable
 
 -- | A shard iterator provides information about how to retrieve stream records
@@ -70,7 +70,7 @@ data GetShardIterator
     -- ^ Determines how the shard iterator is used to start reading stream
     -- records from the shard.
 
-  , _gsiStreamArn ∷ !T.Text
+  , _gsiStreamArn ∷ !Arn
   } deriving (Eq, Ord, Read, Show, Typeable)
 
 -- | A basic 'GetShardIterator' request for a given stream id.
@@ -82,7 +82,7 @@ data GetShardIterator
 -- @
 --
 getShardIterator
-  ∷ T.Text
+  ∷ Arn
   → ShardId
   → ShardIteratorType
   → GetShardIterator
@@ -167,7 +167,7 @@ gsiShardIteratorType i GetShardIterator{..} =
 --
 gsiStreamArn
   ∷ Functor f
-  ⇒ (T.Text → f T.Text)
+  ⇒ (Arn → f Arn)
   → GetShardIterator
   → f GetShardIterator
 gsiStreamArn i GetShardIterator{..} =

--- a/src/Aws/DynamoDb/Streams/Commands/GetShardIterator.hs
+++ b/src/Aws/DynamoDb/Streams/Commands/GetShardIterator.hs
@@ -36,7 +36,7 @@ module Aws.DynamoDb.Streams.Commands.GetShardIterator
 , gsiSequenceNumber
 , gsiShardId
 , gsiShardIteratorType
-, gsiStreamId
+, gsiStreamArn
 
   -- * Response
 , GetShardIteratorResponse(..)
@@ -50,6 +50,7 @@ import Aws.DynamoDb.Streams.Types
 import Control.Applicative
 import Control.Applicative.Unicode
 import Data.Aeson
+import qualified Data.Text as T
 import Data.Typeable
 
 -- | A shard iterator provides information about how to retrieve stream records
@@ -69,7 +70,7 @@ data GetShardIterator
     -- ^ Determines how the shard iterator is used to start reading stream
     -- records from the shard.
 
-  , _gsiStreamId ∷ !StreamId
+  , _gsiStreamArn ∷ !T.Text
   } deriving (Eq, Ord, Read, Show, Typeable)
 
 -- | A basic 'GetShardIterator' request for a given stream id.
@@ -81,13 +82,13 @@ data GetShardIterator
 -- @
 --
 getShardIterator
-  ∷ StreamId
+  ∷ T.Text
   → ShardId
   → ShardIteratorType
   → GetShardIterator
 getShardIterator stream shard iteratorType =
   GetShardIterator
-    { _gsiStreamId = stream
+    { _gsiStreamArn = stream
     , _gsiShardIteratorType = iteratorType
     , _gsiShardId = shard
     , _gsiSequenceNumber = Nothing
@@ -98,7 +99,7 @@ instance ToJSON GetShardIterator where
     [ "SequenceNumber" .= _gsiSequenceNumber
     , "ShardId" .= _gsiShardId
     , "ShardIteratorType" .= _gsiShardIteratorType
-    , "StreamId" .= _gsiStreamId
+    , "StreamArn" .= _gsiStreamArn
     ]
 
 instance FromJSON GetShardIterator where
@@ -108,7 +109,7 @@ instance FromJSON GetShardIterator where
         ⊛ o .:? "SequenceNumber"
         ⊛ o .: "ShardId"
         ⊛ o .: "ShardIteratorType"
-        ⊛ o .: "StreamId"
+        ⊛ o .: "StreamArn"
 
 -- | A lens for '_gsiSequenceNumber'.
 --
@@ -158,21 +159,21 @@ gsiShardIteratorType i GetShardIterator{..} =
     <$> i _gsiShardIteratorType
 {-# INLINE gsiShardIteratorType #-}
 
--- | A lens for '_gsiStreamId'.
+-- | A lens for '_gsiStreamArn'.
 --
 -- @
--- 'gsiStreamId' ∷ Lens' 'GetShardIterator' 'StreamId'
+-- 'gsiStreamArn' ∷ Lens' 'GetShardIterator' 'StreamArn'
 -- @
 --
-gsiStreamId
+gsiStreamArn
   ∷ Functor f
-  ⇒ (StreamId → f StreamId)
+  ⇒ (T.Text → f T.Text)
   → GetShardIterator
   → f GetShardIterator
-gsiStreamId i GetShardIterator{..} =
-  (\_gsiStreamId → GetShardIterator{..})
-    <$> i _gsiStreamId
-{-# INLINE gsiStreamId #-}
+gsiStreamArn i GetShardIterator{..} =
+  (\_gsiStreamArn → GetShardIterator{..})
+    <$> i _gsiStreamArn
+{-# INLINE gsiStreamArn #-}
 
 data GetShardIteratorResponse
   = GetShardIteratorResponse

--- a/src/Aws/DynamoDb/Streams/Commands/ListStreams.hs
+++ b/src/Aws/DynamoDb/Streams/Commands/ListStreams.hs
@@ -33,7 +33,7 @@ module Aws.DynamoDb.Streams.Commands.ListStreams
   ListStreams(..)
 , listStreams
   -- ** Lenses
-, lstExclusiveStartStreamId
+, lstExclusiveStartStreamArn
 , lstLimit
 , lstTableName
 
@@ -41,8 +41,8 @@ module Aws.DynamoDb.Streams.Commands.ListStreams
 , ListStreamsResponse(..)
 
   -- ** Lenses
-, lstrLastEvalutedStreamId
-, lstrStreamIds
+, lstrLastEvaluatedStreamArn
+, lstrStreams
 ) where
 
 import Aws.Core
@@ -53,15 +53,14 @@ import Control.Applicative
 import Control.Applicative.Unicode
 import Data.Aeson
 import Data.Monoid
-import Data.Typeable
-
 import qualified Data.Text as T
+import Data.Typeable
 
 data ListStreams
   = ListStreams
-  { _lstExclusiveStartStreamId ∷ !(Maybe StreamId)
-    -- ^ The stream ID of the first item that this operation will evaluate;
-    -- also see '_lstrLastEvalutedStreamId'.
+  { _lstExclusiveStartStreamArn ∷ !(Maybe T.Text)
+    -- ^ The stream ARN of the first item that this operation will evaluate;
+    -- also see '_lstrLastEvaluatedStreamArn'.
 
   , _lstLimit ∷ !(Maybe Int)
     -- ^ The maximum number of streams to return.
@@ -75,7 +74,7 @@ data ListStreams
 
 instance ToJSON ListStreams where
   toJSON ListStreams{..} = object
-    [ "ExclusiveStartStreamId" .= _lstExclusiveStartStreamId
+    [ "ExclusiveStartStreamArn" .= _lstExclusiveStartStreamArn
     , "Limit" .= _lstLimit
     , "TableName" .= _lstTableName
     ]
@@ -84,7 +83,7 @@ instance FromJSON ListStreams where
   parseJSON =
     withObject "ListStreams" $ \o →
       pure ListStreams
-        ⊛ o .:? "ExclusiveStartStreamId"
+        ⊛ o .:? "ExclusiveStartStreamArn"
         ⊛ o .:? "Limit"
         ⊛ o .:? "TableName"
 
@@ -92,7 +91,7 @@ instance FromJSON ListStreams where
 instance Monoid ListStreams where
   mempty = listStreams
   ls `mappend` ls' = ListStreams
-    { _lstExclusiveStartStreamId = _lstExclusiveStartStreamId ls <|> _lstExclusiveStartStreamId ls'
+    { _lstExclusiveStartStreamArn = _lstExclusiveStartStreamArn ls <|> _lstExclusiveStartStreamArn ls'
     , _lstLimit = _lstLimit ls <|> _lstLimit ls'
     , _lstTableName = _lstTableName ls <|> _lstTableName ls'
     }
@@ -105,26 +104,26 @@ instance Monoid ListStreams where
 --
 listStreams ∷ ListStreams
 listStreams = ListStreams
-  { _lstExclusiveStartStreamId = Nothing
+  { _lstExclusiveStartStreamArn = Nothing
   , _lstLimit = Nothing
   , _lstTableName = Nothing
   }
 
--- | A lens for '_lstExclusiveStartStreamId'.
+-- | A lens for '_lstExclusiveStartStreamArn'.
 --
 -- @
--- lstExclusiveStartStreamId ∷ Lens' 'ListStreams' ('Maybe' 'StreamId')
+-- lstExclusiveStartStreamArn ∷ Lens' 'ListStreams' ('Maybe' 'T.Text')
 -- @
 --
-lstExclusiveStartStreamId
+lstExclusiveStartStreamArn
   ∷ Functor f
-  ⇒ (Maybe StreamId → f (Maybe StreamId))
+  ⇒ (Maybe T.Text → f (Maybe T.Text))
   → ListStreams
   → f ListStreams
-lstExclusiveStartStreamId i ListStreams{..} =
-  (\_lstExclusiveStartStreamId → ListStreams{..})
-    <$> i _lstExclusiveStartStreamId
-{-# INLINE lstExclusiveStartStreamId #-}
+lstExclusiveStartStreamArn i ListStreams{..} =
+  (\_lstExclusiveStartStreamArn → ListStreams{..})
+    <$> i _lstExclusiveStartStreamArn
+{-# INLINE lstExclusiveStartStreamArn #-}
 
 -- | A lens for '_lstlimit'.
 --
@@ -161,58 +160,58 @@ lstTableName i ListStreams{..} =
 
 data ListStreamsResponse
   = ListStreamsResponse
-  { _lstrLastEvalutedStreamId ∷ !(Maybe StreamId)
+  { _lstrLastEvaluatedStreamArn ∷ !(Maybe T.Text)
     -- ^ When empty, this indicates that there are no more streams to be
     -- retrieved.
 
-  , _lstrStreamIds ∷ ![StreamId]
+  , _lstrStreams ∷ ![Stream]
     -- ^ A list of stream IDs associated with the current account and endpoint.
   } deriving (Eq, Ord, Read, Show, Typeable)
 
 instance ToJSON ListStreamsResponse where
   toJSON ListStreamsResponse{..} = object
-    [ "LastEvaluatedStreamId" .= _lstrLastEvalutedStreamId
-    , "StreamIds" .= _lstrStreamIds
+    [ "LastEvaluatedStreamArn" .= _lstrLastEvaluatedStreamArn
+    , "Streams" .= _lstrStreams
     ]
 
 instance FromJSON ListStreamsResponse where
   parseJSON =
     withObject "ListStreamsResponse" $ \o →
       pure ListStreamsResponse
-        ⊛ o .:? "LastEvaluatedStreamId"
-        ⊛ o .:? "StreamIds" .!= []
+        ⊛ o .:? "LastEvaluatedStreamArn"
+        ⊛ o .:? "Streams" .!= []
 
--- | A lens for '_lstrLastEvalutedStreamId'.
+-- | A lens for '_lstrLastEvaluatedStreamArn'.
 --
 -- @
--- lstrLastEvalutedStreamId ∷ Lens' 'ListStreamsResponse' ('Maybe' 'StreamId')
+-- lstrLastEvaluatedStreamArn ∷ Lens' 'ListStreamsResponse' ('Maybe' 'T.Text')
 -- @
 --
-lstrLastEvalutedStreamId
+lstrLastEvaluatedStreamArn
   ∷ Functor f
-  ⇒ (Maybe StreamId → f (Maybe StreamId))
+  ⇒ (Maybe T.Text → f (Maybe T.Text))
   → ListStreamsResponse
   → f ListStreamsResponse
-lstrLastEvalutedStreamId i ListStreamsResponse{..} =
-  (\_lstrLastEvalutedStreamId → ListStreamsResponse{..})
-    <$> i _lstrLastEvalutedStreamId
-{-# INLINE lstrLastEvalutedStreamId #-}
+lstrLastEvaluatedStreamArn i ListStreamsResponse{..} =
+  (\_lstrLastEvaluatedStreamArn → ListStreamsResponse{..})
+    <$> i _lstrLastEvaluatedStreamArn
+{-# INLINE lstrLastEvaluatedStreamArn #-}
 
--- | A lens for '_lstrStreamIds'.
+-- | A lens for '_lstrStreams'.
 --
 -- @
--- lstrStreamIds ∷ Lens' 'ListStreamsResponse' ['StreamId']
+-- lstrStreams ∷ Lens' 'ListStreamsResponse' ['Stream']
 -- @
 --
-lstrStreamIds
+lstrStreams
   ∷ Functor f
-  ⇒ ([StreamId] → f [StreamId])
+  ⇒ ([Stream] → f [Stream])
   → ListStreamsResponse
   → f ListStreamsResponse
-lstrStreamIds i ListStreamsResponse{..} =
-  (\_lstrStreamIds → ListStreamsResponse{..})
-    <$> i _lstrStreamIds
-{-# INLINE lstrStreamIds #-}
+lstrStreams i ListStreamsResponse{..} =
+  (\_lstrStreams → ListStreamsResponse{..})
+    <$> i _lstrStreams
+{-# INLINE lstrStreams #-}
 
 instance ResponseConsumer r ListStreamsResponse where
   type ResponseMetadata ListStreamsResponse = StreamsMetadata
@@ -231,12 +230,12 @@ instance AsMemoryResponse ListStreamsResponse where
   type MemoryResponse ListStreamsResponse = ListStreamsResponse
   loadToMemory = return
 
-instance ListResponse ListStreamsResponse StreamId where
-  listResponse = _lstrStreamIds
+instance ListResponse ListStreamsResponse Stream where
+  listResponse = _lstrStreams
 
 instance IteratedTransaction ListStreams ListStreamsResponse where
   nextIteratedRequest req@ListStreams{..} ListStreamsResponse{..} = do
-    lastEvaluatedStreamId ← _lstrLastEvalutedStreamId
+    lastEvaluatedStreamArn ← _lstrLastEvaluatedStreamArn
     return req
-      { _lstExclusiveStartStreamId = Just lastEvaluatedStreamId
+      { _lstExclusiveStartStreamArn = Just lastEvaluatedStreamArn
       }

--- a/src/Aws/DynamoDb/Streams/Types.hs
+++ b/src/Aws/DynamoDb/Streams/Types.hs
@@ -1098,7 +1098,7 @@ _StatusDisabled =
 
 data Stream
   = Stream
-  { _sStreamArn ∷ !(Maybe T.Text)
+  { _sStreamArn ∷ !(Maybe Arn)
   , _sStreamLabel ∷ !(Maybe StreamLabel)
   , _sTableName ∷ !(Maybe T.Text)
   } deriving (Eq, Ord, Show, Read, Typeable)
@@ -1126,7 +1126,7 @@ instance FromJSON Stream where
 --
 sStreamArn
   ∷ Functor f
-  ⇒ (Maybe T.Text → f (Maybe T.Text))
+  ⇒ (Maybe Arn → f (Maybe Arn))
   → Stream
   → f Stream
 sStreamArn i Stream{..} =
@@ -1172,7 +1172,7 @@ data StreamDescription
   , _sdKeySchema ∷ ![KeySchemaElement]
   , _sdLastEvaluatedShardId ∷ !(Maybe ShardId)
   , _sdShards ∷ ![Shard]
-  , _sdStreamArn ∷ !(Maybe T.Text)
+  , _sdStreamArn ∷ !(Maybe Arn)
   , _sdStreamLabel ∷ !(Maybe StreamLabel)
   , _sdStreamStatus ∷ !(Maybe StreamStatus)
   , _sdStreamViewType ∷ !(Maybe StreamViewType)
@@ -1277,7 +1277,7 @@ sdShards i StreamDescription{..} =
 --
 sdStreamArn
   ∷ Functor f
-  ⇒ (Maybe T.Text → f (Maybe T.Text))
+  ⇒ (Maybe Arn → f (Maybe Arn))
   → StreamDescription
   → f StreamDescription
 sdStreamArn i StreamDescription{..} =

--- a/src/Aws/DynamoDb/Streams/Types.hs
+++ b/src/Aws/DynamoDb/Streams/Types.hs
@@ -129,17 +129,21 @@ module Aws.DynamoDb.Streams.Types
 , _StatusDisabled
 
   -- ** Stream Description
-, StreamId
+, Stream(..)
+, StreamLabel
 , StreamDescription(..)
   -- *** Lenses
 , sdCreationRequestDateTime
 , sdKeySchema
 , sdLastEvaluatedShardId
 , sdShards
-, sdStreamARN
-, sdStreamId
+, sStreamArn
+, sdStreamArn
+, sStreamLabel
+, sdStreamLabel
 , sdStreamStatus
 , sdStreamViewType
+, sTableName
 , sdTableName
 ) where
 
@@ -966,18 +970,18 @@ strStreamViewType i StreamRecord{..} =
 --
 -- Length constraints: @56 ≤ n ≤ 128@.
 --
-newtype StreamId
-  = StreamId
+newtype StreamLabel
+  = StreamLabel
   { _stidText ∷ T.Text
   } deriving (Eq, Ord, Typeable, Show, Read)
 
-instance ToJSON StreamId where
+instance ToJSON StreamLabel where
   toJSON = toJSON ∘ _stidText
 
-instance FromJSON StreamId where
+instance FromJSON StreamLabel where
   parseJSON =
-    withText "StreamId" $
-      pure ∘ StreamId
+    withText "StreamLabel" $
+      pure ∘ StreamLabel
 
 data StreamStatus
   = StatusEnabling
@@ -1092,6 +1096,75 @@ _StatusDisabled =
       fro = either pure (const $ pure StatusDisabled)
 {-# INLINE _StatusDisabled #-}
 
+data Stream
+  = Stream
+  { _sStreamArn ∷ !(Maybe T.Text)
+  , _sStreamLabel ∷ !(Maybe StreamLabel)
+  , _sTableName ∷ !(Maybe T.Text)
+  } deriving (Eq, Ord, Show, Read, Typeable)
+
+instance ToJSON Stream where
+  toJSON Stream{..} = object
+    [ "StreamArn" .= _sStreamArn
+    , "StreamLabel" .= _sStreamLabel
+    , "TableName" .= _sTableName
+    ]
+
+instance FromJSON Stream where
+  parseJSON =
+    withObject "Stream" $ \o →
+      pure Stream
+        ⊛ o .:? "StreamArn"
+        ⊛ o .:? "StreamLabel"
+        ⊛ o .:? "TableName"
+
+-- | A lens for '_sdStreamArn'.
+--
+-- @
+-- 'sdStreamArn' ∷ Lens' 'StreamDescription' ('Maybe' 'T.Text')
+-- @
+--
+sStreamArn
+  ∷ Functor f
+  ⇒ (Maybe T.Text → f (Maybe T.Text))
+  → Stream
+  → f Stream
+sStreamArn i Stream{..} =
+  (\_sStreamArn → Stream{..})
+    <$> i _sStreamArn
+{-# INLINE sStreamArn #-}
+
+-- | A lens for '_sdStreamLabel'.
+--
+-- @
+-- 'sdStreamLabel' ∷ Lens' 'StreamDescription' ('Maybe' 'StreamLabel')
+-- @
+--
+sStreamLabel
+  ∷ Functor f
+  ⇒ (Maybe StreamLabel → f (Maybe StreamLabel))
+  → Stream
+  → f Stream
+sStreamLabel i Stream{..} =
+  (\_sStreamLabel → Stream{..})
+    <$> i _sStreamLabel
+{-# INLINE sStreamLabel #-}
+
+-- | A lens for '_sdTableName'.
+--
+-- @
+-- 'sdTableName' ∷ Lens' 'StreamDescription' ('Maybe' 'T.Text')
+-- @
+--
+sTableName
+  ∷ Functor f
+  ⇒ (Maybe T.Text → f (Maybe T.Text))
+  → Stream
+  → f Stream
+sTableName i Stream{..} =
+  (\_sTableName → Stream{..})
+    <$> i _sTableName
+{-# INLINE sTableName #-}
 
 data StreamDescription
   = StreamDescription
@@ -1099,8 +1172,8 @@ data StreamDescription
   , _sdKeySchema ∷ ![KeySchemaElement]
   , _sdLastEvaluatedShardId ∷ !(Maybe ShardId)
   , _sdShards ∷ ![Shard]
-  , _sdStreamARN ∷ !(Maybe T.Text)
-  , _sdStreamId ∷ !(Maybe StreamId)
+  , _sdStreamArn ∷ !(Maybe T.Text)
+  , _sdStreamLabel ∷ !(Maybe StreamLabel)
   , _sdStreamStatus ∷ !(Maybe StreamStatus)
   , _sdStreamViewType ∷ !(Maybe StreamViewType)
   , _sdTableName ∷ !(Maybe T.Text)
@@ -1111,8 +1184,8 @@ instance ToJSON StreamDescription where
     [ "CreationRequestDateTime" .= (Number ∘ fromInteger ∘ round ∘ utcTimeToPOSIXSeconds <$> _sdCreationRequestDateTime)
     , "KeySchema" .= _sdKeySchema
     , "Shards" .= _sdShards
-    , "StreamARN" .= _sdStreamARN
-    , "StreamId" .= _sdStreamId
+    , "StreamArn" .= _sdStreamArn
+    , "StreamLabel" .= _sdStreamLabel
     , "StreamStatus" .= _sdStreamStatus
     , "StreamViewType" .= _sdStreamViewType
     , "TableName" .= _sdTableName
@@ -1126,8 +1199,8 @@ instance FromJSON StreamDescription where
         ⊛ o .:? "KeySchema" .!= []
         ⊛ o .:? "LastEvaluatedShardId"
         ⊛ o .:? "Shards" .!= []
-        ⊛ o .:? "StreamARN"
-        ⊛ o .:? "StreamId"
+        ⊛ o .:? "StreamArn"
+        ⊛ o .:? "StreamLabel"
         ⊛ o .:? "StreamStatus"
         ⊛ o .:? "StreamViewType"
         ⊛ o .:? "TableName"
@@ -1196,37 +1269,37 @@ sdShards i StreamDescription{..} =
     <$> i _sdShards
 {-# INLINE sdShards #-}
 
--- | A lens for '_sdStreamARN'.
+-- | A lens for '_sdStreamArn'.
 --
 -- @
--- 'sdStreamARN' ∷ Lens' 'StreamDescription' ('Maybe' 'T.Text')
+-- 'sdStreamArn' ∷ Lens' 'StreamDescription' ('Maybe' 'T.Text')
 -- @
 --
-sdStreamARN
+sdStreamArn
   ∷ Functor f
   ⇒ (Maybe T.Text → f (Maybe T.Text))
   → StreamDescription
   → f StreamDescription
-sdStreamARN i StreamDescription{..} =
-  (\_sdStreamARN → StreamDescription{..})
-    <$> i _sdStreamARN
-{-# INLINE sdStreamARN #-}
+sdStreamArn i StreamDescription{..} =
+  (\_sdStreamArn → StreamDescription{..})
+    <$> i _sdStreamArn
+{-# INLINE sdStreamArn #-}
 
--- | A lens for '_sdStreamId'.
+-- | A lens for '_sdStreamLabel'.
 --
 -- @
--- 'sdStreamId' ∷ Lens' 'StreamDescription' ('Maybe' 'StreamId')
+-- 'sdStreamLabel' ∷ Lens' 'StreamDescription' ('Maybe' 'StreamLabel')
 -- @
 --
-sdStreamId
+sdStreamLabel
   ∷ Functor f
-  ⇒ (Maybe StreamId → f (Maybe StreamId))
+  ⇒ (Maybe StreamLabel → f (Maybe StreamLabel))
   → StreamDescription
   → f StreamDescription
-sdStreamId i StreamDescription{..} =
-  (\_sdStreamId → StreamDescription{..})
-    <$> i _sdStreamId
-{-# INLINE sdStreamId #-}
+sdStreamLabel i StreamDescription{..} =
+  (\_sdStreamLabel → StreamDescription{..})
+    <$> i _sdStreamLabel
+{-# INLINE sdStreamLabel #-}
 
 -- | A lens for '_sdStreamStatus'.
 --


### PR DESCRIPTION
The responses changed slightly since the preview. This commit updates it
to what the service currently responds with.

Biggest change is that there is no stream identifier, instead each
stream is now given an ARN.

The README.md now prints a successful response.
